### PR TITLE
feat: upgrade moengage sdk version to latest v9.18.0

### DIFF
--- a/.github/workflows/deploy-cocoapods-manual.yml
+++ b/.github/workflows/deploy-cocoapods-manual.yml
@@ -1,0 +1,22 @@
+name: Manually deploy to Cocoapods
+
+on:
+  workflow_dispatch
+
+jobs:
+  deploy-cocoapods-manual:
+    name: Manually deploy to Cocoapods
+    runs-on: macOS-latest
+    if: startsWith(github.ref, 'refs/heads/master')
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v4
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Publish to CocoaPod
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push --allow-warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 ### Added
 - Release version 1.0.0
 
-## Version - 2.0.0 - 2022-08-07
+## Version - 2.0.0 - 2022-08-21
 ### Added
 - Release version 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 ### Added
 - Release version 1.0.0
 
-## Version - 1.1.0 - 2022-08-06
+## Version - 2.0.0 - 2022-08-07
 ### Added
-- Release version 1.1.0
+- Release version 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## Version - 1.0.0 - 2022-05-25
 ### Added
 - Release version 1.0.0
+
+## Version - 1.1.0 - 2022-08-06
+### Added
+- Release version 1.1.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @soumyadebm
+* @rudderlabs/sdk-ios

--- a/Examples/SampleAppObjC/SampleAppObjC.xcodeproj/project.pbxproj
+++ b/Examples/SampleAppObjC/SampleAppObjC.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 /* Begin PBXFileReference section */
 		19B6062B17239ADFE2C3A8D1 /* Pods_SampleAppObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleAppObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		48449361100A5BC94930FCDC /* Pods-SampleAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleAppObjC.debug.xcconfig"; path = "Target Support Files/Pods-SampleAppObjC/Pods-SampleAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
+		990922202C6BB3550071C6D6 /* SampleAppObjC.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SampleAppObjC.entitlements; sourceTree = "<group>"; };
 		D2416FCCDF8938B9658A5B89 /* Pods-SampleAppObjC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleAppObjC.release.xcconfig"; path = "Target Support Files/Pods-SampleAppObjC/Pods-SampleAppObjC.release.xcconfig"; sourceTree = "<group>"; };
 		EDB7217F27DB4F70000EE8C4 /* SampleAppObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleAppObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDB7218227DB4F70000EE8C4 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -86,6 +87,7 @@
 		EDB7218127DB4F70000EE8C4 /* SampleAppObjC */ = {
 			isa = PBXGroup;
 			children = (
+				990922202C6BB3550071C6D6 /* SampleAppObjC.entitlements */,
 				EDB7218227DB4F70000EE8C4 /* AppDelegate.h */,
 				EDB7218327DB4F70000EE8C4 /* AppDelegate.m */,
 				EDB7218527DB4F70000EE8C4 /* SceneDelegate.h */,
@@ -363,6 +365,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SampleAppObjC/SampleAppObjC.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = UCL2K3J73M;
@@ -393,6 +396,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SampleAppObjC/SampleAppObjC.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = UCL2K3J73M;

--- a/Examples/SampleAppObjC/SampleAppObjC.xcodeproj/project.pbxproj
+++ b/Examples/SampleAppObjC/SampleAppObjC.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -365,7 +365,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Z6DGB573C6;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SampleAppObjC/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -395,7 +395,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Z6DGB573C6;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SampleAppObjC/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Examples/SampleAppObjC/SampleAppObjC/AppDelegate.m
+++ b/Examples/SampleAppObjC/SampleAppObjC/AppDelegate.m
@@ -9,6 +9,7 @@
 
 @import Rudder;
 @import RudderMoEngage;
+@import MoEngageSDK;
 #import <UserNotifications/UserNotifications.h>
 
 @interface AppDelegate () <UNUserNotificationCenterDelegate>
@@ -20,8 +21,8 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
-    RSConfig *config = [[RSConfig alloc] initWithWriteKey:@"<WRITE_KEY>"];
-    [config dataPlaneURL:@"<DATA_PLANE_URL>"];
+    RSConfig *config = [[RSConfig alloc] initWithWriteKey:@"2k3Dk3s8vs7Y8JPoCfWPQd4Pm54"];
+    [config dataPlaneURL:@"https://rudderstacuodq.dataplane.rudderstack.com"];
     [config loglevel:RSLogLevelVerbose];
     [config trackLifecycleEvents:YES];
     [config recordScreenViews:YES];
@@ -35,15 +36,18 @@
     if (@available(iOS 10.0, *)) {
         UNUserNotificationCenter.currentNotificationCenter.delegate = self;
     }
+   
+    
     return YES;
 }
+
 
 
 #pragma mark - UISceneSession lifecycle
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
     [[RSClient sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-
+ 
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
@@ -57,6 +61,8 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     [[RSClient sharedInstance] application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
 }
+
+
 
 
 - (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {

--- a/Examples/SampleAppObjC/SampleAppObjC/AppDelegate.m
+++ b/Examples/SampleAppObjC/SampleAppObjC/AppDelegate.m
@@ -33,22 +33,10 @@
     [client addDestination:[[RudderMoEngageDestination alloc] init]];
     [client track:@"Track 1"];
     
-//    if (@available(iOS 10.0, *)) {
-//        UNUserNotificationCenter.currentNotificationCenter.delegate = self;
-//    }
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert + UNAuthorizationOptionSound + UNAuthorizationOptionBadge)
-                              completionHandler:^(BOOL granted, NSError * _Nullable error) {
-                                  if (!error) {
-                                      NSLog(@"Request authorization succeeded!");
-                                  }
-                              }];
-        
-        // Register with APNs
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-    [[MoEngageSDKMessaging sharedInstance] registerForRemoteNotificationWithCategories:nil andUserNotificationCenterDelegate:self];
-    
- 
+    if (@available(iOS 10.0, *)) {
+        UNUserNotificationCenter.currentNotificationCenter.delegate = self;
+    }
+   
     
     return YES;
 }
@@ -58,11 +46,7 @@
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
     [[RSClient sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-    NSString *deviceTokenString = [self deviceTokenToString:deviceToken];
-        NSLog(@"Device Token: %@", deviceTokenString);
-    //[[MoEngageSDKMessaging sharedInstance] setPushToken:deviceToken];
     
-    [[RSClient sharedInstance] setDeviceToken:deviceTokenString];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {

--- a/Examples/SampleAppObjC/SampleAppObjC/AppDelegate.m
+++ b/Examples/SampleAppObjC/SampleAppObjC/AppDelegate.m
@@ -20,9 +20,9 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
-    RSConfig *config = [[RSConfig alloc] initWithWriteKey:@"27COeQCO3BS2WMw8CJUqYRC5hL7"];
-    [config dataPlaneURL:@"https://rudderstacz.dataplane.rudderstack.com"];
-    [config loglevel:RSLogLevelDebug];
+    RSConfig *config = [[RSConfig alloc] initWithWriteKey:@"<WRITE_KEY>"];
+    [config dataPlaneURL:@"<DATA_PLANE_URL>"];
+    [config loglevel:RSLogLevelVerbose];
     [config trackLifecycleEvents:YES];
     [config recordScreenViews:YES];
     

--- a/Examples/SampleAppObjC/SampleAppObjC/SampleAppObjC.entitlements
+++ b/Examples/SampleAppObjC/SampleAppObjC/SampleAppObjC.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Examples/SampleAppObjC/SampleAppObjC/SampleAppObjC.entitlements
+++ b/Examples/SampleAppObjC/SampleAppObjC/SampleAppObjC.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
 </plist>

--- a/Examples/SampleAppObjC/SampleAppObjC/ViewController.m
+++ b/Examples/SampleAppObjC/SampleAppObjC/ViewController.m
@@ -6,6 +6,8 @@
 //
 
 #import "ViewController.h"
+@import Rudder;
+
 
 @interface ViewController ()
 
@@ -16,6 +18,33 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
+    
+    NSDate *birthday = [[NSDate alloc] init];
+    [[RSClient sharedInstance] identify:@"New User 2" traits: @{
+        @"birthday": birthday,
+        @"address": @{
+            @"city": @"Kolkata",
+            @"country": @"India"
+        },
+        @"firstname": @"Shweta",
+        @"lastname": @"Salvi",
+        @"name": @"Shweta",
+        @"gender": @"female",
+        @"phone": @"0123456789",
+        @"email": @"User1@gmail.com",
+        @"key-1": @"value-1",
+        @"key-2": @1234
+    }];
+    
+    [[RSClient sharedInstance] track:@"New Track event"];
+    
+    [[RSClient sharedInstance] track:@"New Track event" properties:@{
+        @"key_1" : @"value_1",
+        @"key_2" : @"value_2"
+    }];
+    
+    [[RSClient sharedInstance] alias:@"New User 2"];
+    
 }
 
 

--- a/Examples/SampleAppSwift/SampleAppSwift.xcodeproj/project.pbxproj
+++ b/Examples/SampleAppSwift/SampleAppSwift.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -364,7 +364,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = SampleAppSwift/SampleAppSwift.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GTGKNDBD23;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				INFOPLIST_FILE = "$(SRCROOT)/SampleAppSwift/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -372,7 +372,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.RudderMoEngage;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.RudderMoEngagev2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -386,7 +386,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = SampleAppSwift/SampleAppSwift.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GTGKNDBD23;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				INFOPLIST_FILE = "$(SRCROOT)/SampleAppSwift/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -394,7 +394,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.RudderMoEngage;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.RudderMoEngagev2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
+++ b/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
@@ -19,8 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        let config: RSConfig = RSConfig(writeKey: "<WRITE_KEY>")
-            .dataPlaneURL("<DATA_PLANE_URL>")
+        let config: RSConfig = RSConfig(writeKey: "2k3Dk3s8vs7Y8JPoCfWPQd4Pm54")
+            .dataPlaneURL("https://rudderstacuodq.dataplane.rudderstack.com")
             .loglevel(.debug)
             .trackLifecycleEvents(false)
             .recordScreenViews(false)

--- a/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
+++ b/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
@@ -19,8 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        let config: RSConfig = RSConfig(writeKey: "2k3Dk3s8vs7Y8JPoCfWPQd4Pm54")
-            .dataPlaneURL("https://rudderstacuodq.dataplane.rudderstack.com")
+        let config: RSConfig = RSConfig(writeKey: "<WRITE_KEY>")
+            .dataPlaneURL("DATA_PLANE_URL>")
             .loglevel(.debug)
             .trackLifecycleEvents(false)
             .recordScreenViews(false)

--- a/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
+++ b/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
@@ -19,8 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        let config: RSConfig = RSConfig(writeKey: "2k3Dk3s8vs7Y8JPoCfWPQd4Pm54")
-            .dataPlaneURL("https://rudderstacuodq.dataplane.rudderstack.com")
+        let config: RSConfig = RSConfig(writeKey: "<WRITE_KEY>")
+            .dataPlaneURL("<DATA_PLANE_URL>")
             .loglevel(.debug)
             .trackLifecycleEvents(false)
             .recordScreenViews(false)

--- a/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
+++ b/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
@@ -19,8 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        let config: RSConfig = RSConfig(writeKey: "<WRITE_KEY>")
-            .dataPlaneURL("<DATA_PLANE_URL>")
+        let config: RSConfig = RSConfig(writeKey: "2k3Dk3s8vs7Y8JPoCfWPQd4Pm54")
+            .dataPlaneURL("https://rudderstacuodq.dataplane.rudderstack.com")
             .loglevel(.debug)
             .trackLifecycleEvents(false)
             .recordScreenViews(false)
@@ -30,8 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         client?.addDestination(RudderMoEngageDestination())
 
-       // sendEvents()
-      
+        //sendEvents()
+        sendIdentifyEvents()
 
         if #available(iOS 10.0, *) {
             UNUserNotificationCenter.current().delegate = self

--- a/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
+++ b/Examples/SampleAppSwift/SampleAppSwift/AppDelegate.swift
@@ -19,8 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        let config: RSConfig = RSConfig(writeKey: "27COeQCO3BS2WMw8CJUqYRC5hL7")
-            .dataPlaneURL("https://rudderstacbumvdrexzj.dataplane.rudderstack.com")
+        let config: RSConfig = RSConfig(writeKey: "<WRITE_KEY>")
+            .dataPlaneURL("<DATA_PLANE_URL>")
             .loglevel(.debug)
             .trackLifecycleEvents(false)
             .recordScreenViews(false)
@@ -30,7 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         client?.addDestination(RudderMoEngageDestination())
 
-        sendEvents()
+       // sendEvents()
+      
 
         if #available(iOS 10.0, *) {
             UNUserNotificationCenter.current().delegate = self
@@ -109,12 +110,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     func sendIdentifyEvents() {
-        client?.identify("iOS User with traits 2", traits: [
+        client?.identify("New User 2", traits: [
             "key": "Value",
             "date": Date(),
-            "email": "random@example.com",
+            "email": "User1@gmail.com",
             "name": "Full Name",
-            "phone": 1234567890,
+            "phone": "1234567890",
             "firstName": "FName",
             "lastName": "LName",
             "gender": "Male",

--- a/Examples/SampleAppSwift/SampleAppSwift/Info.plist
+++ b/Examples/SampleAppSwift/SampleAppSwift/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MoEngageAppDelegateProxyEnabled</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -62,7 +64,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>MoEngageAppDelegateProxyEnabled</key>
-	<false/>
 </dict>
 </plist>

--- a/Examples/SampleAppSwift/SampleAppSwift/ViewController.swift
+++ b/Examples/SampleAppSwift/SampleAppSwift/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Rudder
 
 class ViewController: UIViewController {
 
@@ -47,6 +48,8 @@ class ViewController: UIViewController {
             "date_key": Date(),
             "url_key": URL(fileURLWithPath: "https://rudderstack.com")
         ])*/
+        
+
     }
 
 }

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ end
 target 'RudderMoEngage' do
     project 'RudderMoEngage.xcodeproj'
     shared_pods
-    pod 'MoEngage-iOS-SDK', '~> 6.1.0'
+    pod 'MoEngage-iOS-SDK', '~> 9.18.0'
 end
 
 target 'SampleAppObjC' do

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ end
 target 'RudderMoEngage' do
     project 'RudderMoEngage.xcodeproj'
     shared_pods
-    pod 'MoEngage-iOS-SDK', '~> 9.18.0'
+   
 end
 
 target 'SampleAppObjC' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,49 @@
 PODS:
-  - MoEngage-iOS-SDK (6.1.1)
-  - Rudder (2.0.0)
+  - MoEngage-iOS-SDK (9.18.1):
+    - MoEngage-iOS-SDK/Core (= 9.18.1)
+  - MoEngage-iOS-SDK/Core (9.18.1):
+    - MoEngageAnalytics (= 4.18.1)
+    - MoEngageCore (= 9.18.1)
+    - MoEngageMessaging (= 4.18.1)
+    - MoEngageObjCUtils (= 3.18.1)
+    - MoEngageSDK (= 9.18.1)
+    - MoEngageSecurity (= 1.10.1)
+  - MoEngageAnalytics (4.18.1):
+    - MoEngageCore
+    - MoEngageObjCUtils
+  - MoEngageCore (9.18.1):
+    - MoEngageSecurity
+  - MoEngageMessaging (4.18.1):
+    - MoEngageAnalytics
+    - MoEngageCore
+    - MoEngageObjCUtils
+  - MoEngageObjCUtils (3.18.1):
+    - MoEngageCore
+  - MoEngageSDK (9.18.1):
+    - MoEngageAnalytics
+    - MoEngageCore
+    - MoEngageMessaging
+    - MoEngageObjCUtils
+  - MoEngageSecurity (1.10.1)
+  - Rudder (2.0.1)
   - RudderMoEngage (1.0.0):
-    - MoEngage-iOS-SDK (~> 6.1.0)
+    - MoEngage-iOS-SDK (~> 9.18.0)
     - Rudder (~> 2.0.0)
 
 DEPENDENCIES:
-  - MoEngage-iOS-SDK (~> 6.1.0)
+  - MoEngage-iOS-SDK (~> 9.18.0)
   - Rudder (~> 2.0.0)
   - RudderMoEngage (from `.`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - MoEngage-iOS-SDK
+    - MoEngageAnalytics
+    - MoEngageCore
+    - MoEngageMessaging
+    - MoEngageObjCUtils
+    - MoEngageSDK
+    - MoEngageSecurity
     - Rudder
 
 EXTERNAL SOURCES:
@@ -20,10 +51,16 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  MoEngage-iOS-SDK: 47c685f40824ceae1fe0c252d1dc0e85d0f10247
-  Rudder: 3191eb7c0bd0158fc983e0b7e171223f701ebc7c
-  RudderMoEngage: b1e3e696a1b6b9c265a17593201f67160130ef06
+  MoEngage-iOS-SDK: 4acddb45e23dc6b21712228b3507d1e0e16af6fb
+  MoEngageAnalytics: f0606511bf23f9b33dcf25bbc666f152c9c017a6
+  MoEngageCore: 5f5466497ee7c24dcf0a924aafc8585610866295
+  MoEngageMessaging: a96c34322bbf24e650ef4724a5c7cecdceee82a8
+  MoEngageObjCUtils: 4928cbcb57897419069b1486e267b757370aed0d
+  MoEngageSDK: 2996df25a3889894c91da9bf9ab68e2d16f8d49d
+  MoEngageSecurity: 2adeeb8d269f36719e040bfa65a6568a336815ec
+  Rudder: 463af33116984b97f2a19d344e9ad491f164e43e
+  RudderMoEngage: d8589fc9c57f913c20fbc1658c46662862b5d601
 
-PODFILE CHECKSUM: 082aa44bee6476be234bffaafd72193e6499ce5b
+PODFILE CHECKSUM: 8b21a3425bcab041287bcacfb9650eb4b950efda
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.15.2

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository contains the resources and assets required to integrate the [Rud
 2. `RudderMoEngage` is available through [CocoaPods](https://cocoapods.org). To install it, add the following line to your Podfile and followed by `pod install`, as shown:
 
 ```ruby
-pod 'RudderMoEngage', '~> 1.0.0'
+pod 'RudderMoEngage', '~> 1.1.0'
 ```
 
 ## Step 2: Initialize the RudderStack client (`RSClient`)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository contains the resources and assets required to integrate the [Rud
 2. `RudderMoEngage` is available through [CocoaPods](https://cocoapods.org). To install it, add the following line to your Podfile and followed by `pod install`, as shown:
 
 ```ruby
-pod 'RudderMoEngage', '~> 1.1.0'
+pod 'RudderMoEngage', '~> 2.0.0'
 ```
 
 ## Step 2: Initialize the RudderStack client (`RSClient`)

--- a/RudderMoEngage.podspec
+++ b/RudderMoEngage.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
     s.name             = 'RudderMoEngage'
-    s.version          = '1.0.0'
+    s.version          = '1.1.0'
     s.summary          = 'Privacy and Security focused Segment-alternative. MoEngage Native SDK integration support.'
     s.description      = <<-DESC
     Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.
     DESC
     s.homepage         = 'https://github.com/rudderlabs/rudder-integration-moengage-swift'
-    s.license          = { :type => "Apache", :file => "LICENSE" }
+    s.license          = { :type => "Apache", :file => "LICENSE.md" }
     s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
     s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-moengage-swift.git' , :tag => "v#{s.version}" }
     
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
     s.swift_version = '5.3'
 
     s.dependency 'Rudder', '~> 2.0.0'
-    s.dependency 'MoEngage-iOS-SDK', '~> 6.1.0'
+    s.dependency 'MoEngage-iOS-SDK', '~> 9.18.0'
 end

--- a/RudderMoEngage.podspec
+++ b/RudderMoEngage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'RudderMoEngage'
-    s.version          = '1.1.0'
+    s.version          = '2.0.0'
     s.summary          = 'Privacy and Security focused Segment-alternative. MoEngage Native SDK integration support.'
     s.description      = <<-DESC
     Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.

--- a/RudderMoEngage.xcodeproj/project.pbxproj
+++ b/RudderMoEngage.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C0722561749B0FEAC06B726F /* Pods_RudderMoEngage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C50870317EF6150140DEE14B /* Pods_RudderMoEngage.framework */; };
+		5C5C261FE97D1C542805C05F /* Pods_RudderMoEngage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99D028ADF52223C4067B611F /* Pods_RudderMoEngage.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		8528347F9BCC39D6E43450C7 /* Pods-RudderMoEngage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderMoEngage.release.xcconfig"; path = "Target Support Files/Pods-RudderMoEngage/Pods-RudderMoEngage.release.xcconfig"; sourceTree = "<group>"; };
+		89B965E3B5528FA415CF76C2 /* Pods-RudderMoEngage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderMoEngage.debug.xcconfig"; path = "Target Support Files/Pods-RudderMoEngage/Pods-RudderMoEngage.debug.xcconfig"; sourceTree = "<group>"; };
 		8C89A5252810513A0098F12F /* RudderMoEngage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderMoEngage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C89A52728105D380098F12F /* RudderMoEngage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderMoEngage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CE2AB83280FDDCB00321A8D /* RudderMoEngage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RudderMoEngage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C208F6E333BB12073F594A29 /* Pods-RudderMoEngage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderMoEngage.release.xcconfig"; path = "Target Support Files/Pods-RudderMoEngage/Pods-RudderMoEngage.release.xcconfig"; sourceTree = "<group>"; };
-		C50870317EF6150140DEE14B /* Pods_RudderMoEngage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderMoEngage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C735F795CC28360435A383EA /* Pods-RudderMoEngage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderMoEngage.debug.xcconfig"; path = "Target Support Files/Pods-RudderMoEngage/Pods-RudderMoEngage.debug.xcconfig"; sourceTree = "<group>"; };
+		99D028ADF52223C4067B611F /* Pods_RudderMoEngage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderMoEngage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED2A28EB2770560400646788 /* RudderMoEngage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RudderMoEngage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED2A28F72770570400646788 /* RudderMoEngage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RudderMoEngage.h; sourceTree = "<group>"; };
 		ED2A28FA2770591E00646788 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -32,18 +32,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0722561749B0FEAC06B726F /* Pods_RudderMoEngage.framework in Frameworks */,
+				5C5C261FE97D1C542805C05F /* Pods_RudderMoEngage.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		208F25C796D8593BF8DAB48E /* Pods */ = {
+		156DF68C27FC415FFD045AFE /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				C735F795CC28360435A383EA /* Pods-RudderMoEngage.debug.xcconfig */,
-				C208F6E333BB12073F594A29 /* Pods-RudderMoEngage.release.xcconfig */,
+				89B965E3B5528FA415CF76C2 /* Pods-RudderMoEngage.debug.xcconfig */,
+				8528347F9BCC39D6E43450C7 /* Pods-RudderMoEngage.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -54,7 +54,7 @@
 				8C89A52728105D380098F12F /* RudderMoEngage.framework */,
 				8C89A5252810513A0098F12F /* RudderMoEngage.framework */,
 				8CE2AB83280FDDCB00321A8D /* RudderMoEngage.framework */,
-				C50870317EF6150140DEE14B /* Pods_RudderMoEngage.framework */,
+				99D028ADF52223C4067B611F /* Pods_RudderMoEngage.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -69,8 +69,8 @@
 				ED2A28FB2770591E00646788 /* RudderMoEngage.podspec */,
 				ED2A28F52770570400646788 /* Sources */,
 				ED2A28EC2770560400646788 /* Products */,
-				208F25C796D8593BF8DAB48E /* Pods */,
 				7E0239965FFF8180EB820885 /* Frameworks */,
+				156DF68C27FC415FFD045AFE /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -124,7 +124,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED2A28F22770560400646788 /* Build configuration list for PBXNativeTarget "RudderMoEngage" */;
 			buildPhases = (
-				BABAF45010B7EF6EA13413F6 /* [CP] Check Pods Manifest.lock */,
+				8B91A4254352CEC39B78206E /* [CP] Check Pods Manifest.lock */,
 				ED2A28E62770560400646788 /* Headers */,
 				8CFC551428042AB000C41CEA /* Swift Lint */,
 				ED2A28E72770560400646788 /* Sources */,
@@ -184,25 +184,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		8CFC551428042AB000C41CEA /* Swift Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swift Lint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		BABAF45010B7EF6EA13413F6 /* [CP] Check Pods Manifest.lock */ = {
+		8B91A4254352CEC39B78206E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -223,6 +205,24 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		8CFC551428042AB000C41CEA /* Swift Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Swift Lint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -361,7 +361,7 @@
 		};
 		ED2A28F32770560400646788 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C735F795CC28360435A383EA /* Pods-RudderMoEngage.debug.xcconfig */;
+			baseConfigurationReference = 89B965E3B5528FA415CF76C2 /* Pods-RudderMoEngage.debug.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -369,7 +369,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = GTGKNDBD23;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -396,7 +396,7 @@
 		};
 		ED2A28F42770560400646788 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C208F6E333BB12073F594A29 /* Pods-RudderMoEngage.release.xcconfig */;
+			baseConfigurationReference = 8528347F9BCC39D6E43450C7 /* Pods-RudderMoEngage.release.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -404,7 +404,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = GTGKNDBD23;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -61,7 +61,7 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
         }
         
         if let userId = message.userId {
-            MoEngageSDKAnalytics.sharedInstance.setUserAttribute(userId, withAttributeName: "userId")
+          
             MoEngageSDKAnalytics.sharedInstance.setUniqueID(userId)
         }
         

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -45,6 +45,12 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
         if client?.configuration?.logLevel != .none {
             sdkConfig.consoleLogConfig = MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.debug)
         }
+        if client?.configuration?.logLevel != .none {
+            sdkConfig.consoleLogConfig = getMoEngageLogLevel(logLevel: client?.configuration?.logLevel)
+        }
+        
+      
+       
 
         // Check if debug mode is on or off
 #if DEBUG
@@ -139,6 +145,18 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
        MoEngageSDKAnalytics.sharedInstance.flush()
        client?.log(message: "MoEngage Flush API: 'MoEngage.sharedInstance().flush()' is called.", logLevel: .debug)
     }
+    
+    func getMoEngageLogLevel(logLevel: RSLogLevel) -> MoEngageCore.MoEngageConsoleLogConfig {
+            if (logLevel == RSLogLevel.error) {
+                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.error)
+            } else if (logLevel == RSLogLevel.warning) {
+                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.warning)
+            } else if (logLevel == RSLogLevel.info) {
+                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.info)
+            } else if (logLevel == RSLogLevel.debug) {
+                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.verbose)
+            }
+        }
     
 }
 

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -54,6 +54,7 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
         }
         
         client?.log(message: "Initializing MoEngage SDK", logLevel: .debug)
+        MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: .debug)
     }
     
     func identify(message: IdentifyMessage) -> IdentifyMessage? {

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -36,13 +36,14 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
         }
         else{
             client?.log(message:"MoEngage SDK initialization terminated due to an invalid region.", logLevel: .warning)
+            return
         }
        
         let sdkConfig = MoEngageSDKConfig(appId: moEngageConfig.apiId, dataCenter: moEngageDataCenter!)
         
         //enable debugging
         if client?.configuration?.logLevel != .none {
-            MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.debug)
+            sdkConfig.consoleLogConfig = MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.debug)
         }
 
         // Check if debug mode is on or off

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -165,11 +165,23 @@ extension RSMoEngageDestination {
         for (key, value) in traits {
             if value is String || value is NSNumber || value is Date {
                 switch key {
-                case RSKeys.Identify.Traits.email: MoEngageSDKAnalytics.sharedInstance.setEmailID((value as? String)!)
-                case RSKeys.Identify.Traits.name: MoEngageSDKAnalytics.sharedInstance.setName((value as? String)!)
-                case RSKeys.Identify.Traits.phone: MoEngageSDKAnalytics.sharedInstance.setMobileNumber(value as! String)
-                case RSKeys.Identify.Traits.firstName: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: "USER_ATTRIBUTE_USER_FIRST_NAME") 
-                case RSKeys.Identify.Traits.lastName: MoEngageSDKAnalytics.sharedInstance.setLastName((value as? String)!)
+                case RSKeys.Identify.Traits.email:
+                    if let email = value as? String {
+                       MoEngageSDKAnalytics.sharedInstance.setEmailID(email)
+                    }
+                case RSKeys.Identify.Traits.name:
+                    if let name = value as? String {
+                        MoEngageSDKAnalytics.sharedInstance.setName(name)
+                    }
+                case RSKeys.Identify.Traits.phone:
+                    if let phone = value as? String {
+                       MoEngageSDKAnalytics.sharedInstance.setMobileNumber(phone)
+                    }
+                case RSKeys.Identify.Traits.firstName: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: "USER_ATTRIBUTE_USER_FIRST_NAME")
+                case RSKeys.Identify.Traits.lastName:
+                    if let lastName = value as? String {
+                       MoEngageSDKAnalytics.sharedInstance.setLastName(lastName)
+                    }
                 case RSKeys.Identify.Traits.gender: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: "USER_ATTRIBUTE_USER_GENDER")
                 case RSKeys.Identify.Traits.birthday: identifyDateUserAttribute(value: value, key: "USER_ATTRIBUTE_USER_BDAY")
                 case RSKeys.Identify.Traits.address: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: RSKeys.Identify.Traits.address)

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -10,6 +10,8 @@ import Foundation
 import Rudder
 import MoEngageSDK
 
+
+
 class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCenterDelegate {
     let type = PluginType.destination
     let key = "MoEngage"
@@ -177,13 +179,13 @@ extension RSMoEngageDestination {
                     if let phone = value as? String {
                        MoEngageSDKAnalytics.sharedInstance.setMobileNumber(phone)
                     }
-                case RSKeys.Identify.Traits.firstName: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: "USER_ATTRIBUTE_USER_FIRST_NAME")
+                case RSKeys.Identify.Traits.firstName: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: RSKeys.Identify.Traits.firstName)
                 case RSKeys.Identify.Traits.lastName:
                     if let lastName = value as? String {
                        MoEngageSDKAnalytics.sharedInstance.setLastName(lastName)
                     }
-                case RSKeys.Identify.Traits.gender: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: "USER_ATTRIBUTE_USER_GENDER")
-                case RSKeys.Identify.Traits.birthday: identifyDateUserAttribute(value: value, key: "USER_ATTRIBUTE_USER_BDAY")
+                case RSKeys.Identify.Traits.gender: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: RSKeys.Identify.Traits.gender)
+                case RSKeys.Identify.Traits.birthday: identifyDateUserAttribute(value: value, key: RSKeys.Identify.Traits.birthday)
                 case RSKeys.Identify.Traits.address: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: RSKeys.Identify.Traits.address)
                 case RSKeys.Identify.Traits.age: MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: RSKeys.Identify.Traits.age)
                 default: identifyDateUserAttribute(value: value, key: key)

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -78,8 +78,8 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
     func track(message: TrackMessage) -> TrackMessage? {
         if !message.event.isEmpty {
             switch message.event {
-            case RSEvents.LifeCycle.applicationInstalled: MoEngageAppStatus(rawValue: 0)
-            case RSEvents.LifeCycle.applicationUpdated: MoEngageAppStatus.update
+            case RSEvents.LifeCycle.applicationInstalled: MoEngageSDKAnalytics.sharedInstance.appStatus(.install)
+            case RSEvents.LifeCycle.applicationUpdated:  MoEngageSDKAnalytics.sharedInstance.appStatus(.update)
             default:
                 if let properties = message.properties, !properties.isEmpty {
                     let eventProperties: MoEngageProperties = MoEngageProperties()

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -43,9 +43,6 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
         
         //enable debugging
         if client?.configuration?.logLevel != .none {
-            sdkConfig.consoleLogConfig = MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.debug)
-        }
-        if client?.configuration?.logLevel != .none {
             sdkConfig.consoleLogConfig = getMoEngageLogLevel(client?.configuration?.logLevel)
         }
         

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -46,7 +46,7 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
             sdkConfig.consoleLogConfig = MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.debug)
         }
         if client?.configuration?.logLevel != .none {
-            sdkConfig.consoleLogConfig = getMoEngageLogLevel(logLevel: client?.configuration?.logLevel)
+            sdkConfig.consoleLogConfig = getMoEngageLogLevel(client?.configuration?.logLevel)
         }
         
       
@@ -146,17 +146,21 @@ class RSMoEngageDestination: NSObject, RSDestinationPlugin, UNUserNotificationCe
        client?.log(message: "MoEngage Flush API: 'MoEngage.sharedInstance().flush()' is called.", logLevel: .debug)
     }
     
-    func getMoEngageLogLevel(logLevel: RSLogLevel) -> MoEngageCore.MoEngageConsoleLogConfig {
-            if (logLevel == RSLogLevel.error) {
-                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.error)
-            } else if (logLevel == RSLogLevel.warning) {
-                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.warning)
-            } else if (logLevel == RSLogLevel.info) {
-                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.info)
-            } else if (logLevel == RSLogLevel.debug) {
-                return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.verbose)
-            }
+    func getMoEngageLogLevel(_ logLevel: RSLogLevel?) -> MoEngageCore.MoEngageConsoleLogConfig {
+        if (logLevel == RSLogLevel.error) {
+            return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.error)
+        } else if (logLevel == RSLogLevel.warning) {
+            return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.warning)
+        } else if (logLevel == RSLogLevel.info) {
+            return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.info)
+        } else if (logLevel == RSLogLevel.debug) {
+            return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: true, loglevel: MoEngageCore.MoEngageLoggerType.verbose)
         }
+        else {
+            // Provide a default return value or handle the nil/unknown case.
+            return MoEngageCore.MoEngageConsoleLogConfig(isLoggingEnabled: false, loglevel: MoEngageCore.MoEngageLoggerType.verbose)
+        }
+    }
     
 }
 

--- a/Sources/Classes/RSMoEngageDestination.swift
+++ b/Sources/Classes/RSMoEngageDestination.swift
@@ -197,13 +197,17 @@ extension RSMoEngageDestination {
             // Verify if the value is of type Date or not
             // Track UserAttribute using Epoch value. Refer here: https://developers.moengage.com/hc/en-us/articles/4403905883796-Tracking-User-Attributes
             if let value = value as? String, let convertedDate = dateFrom(isoDateString: value) {
-                MoEngageSDKAnalytics.sharedInstance.setUserAttribute(convertedDate.timeIntervalSince1970, withAttributeName: key)
+                MoEngageSDKAnalytics.sharedInstance.setUserAttribute(convertDateToTimestamp(date: convertedDate), withAttributeName: key)
             } else if let value = value as? Date {
                 MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(value, withAttributeName: key)
             } else {
                 MoEngageSDKAnalytics.sharedInstance.setUserAttribute(value, withAttributeName: key)
             }
         }
+    }
+    
+    func convertDateToTimestamp(date: Date) -> TimeInterval {
+        return date.timeIntervalSince1970
     }
     
     func dateFrom(isoDateString: String?) -> Date? {


### PR DESCRIPTION
 # Description

- Separated standard and non-standard traits keys.
- Simplified how standard trait keys are handled. They require a string-type value.
- Non-Standard trait keys could ideally take any values, as the MoEngage does not define them.
- Changed the method name of handleCustomAttribute to handleDateAndCustomUserAttribute. For better readability.
- Removed the identifyDateUserAttribute, as it is not used.
- Refactored the logic of the data handling method in handleDateAndCustomUserAttribute().

Type of change

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

Checklist:

- [ ]  Version updated in README
- [ ]  Version updated in RudderSingular.xcodeproj
- [ ]  Version updated in RudderSingular.podspec
- [ ]  CHANGELOG Updated
- [ ]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have added unit tests for the code
- [ ]  I have made corresponding changes to the documentation
- [ ]  Passed pod lib lint --no-clean --allow-warnings

