### PR TITLE
chore: update manual deployment file master branch name

### DIFF
--- a/.github/workflows/deploy-cocoapods-manual.yml
+++ b/.github/workflows/deploy-cocoapods-manual.yml
@@ -7,7 +7,7 @@ jobs:
   deploy-cocoapods-manual:
     name: Manually deploy to Cocoapods
     runs-on: macOS-latest
-    if: startsWith(github.ref, 'refs/heads/master')
+    if: startsWith(github.ref, 'refs/heads/main')
     steps:
       - name: Checkout source branch
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

- updated `deploy-cocoapods-manual.yml` file with name of `master` to `main`
